### PR TITLE
Configure binder 

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,4 @@
+dependencies:
+  - numpy
+  - matplotlib
+  - tensorflow


### PR DESCRIPTION
Binder needs a list of the dependencies in order to be able to build the correct the docker container and actually run the notebooks: more details here https://mybinder.readthedocs.io/en/latest/using.html#preparing-a-repository-for-binder

Benvingut a github! :wink: 

M'he inventat les dependencies, espero no anar massa desencaminat